### PR TITLE
Generic plugin settings rendering for external players

### DIFF
--- a/src/api/__tests__/playerSettings.test.ts
+++ b/src/api/__tests__/playerSettings.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/stores/appconfig', () => ({
+  useAppConfigStore: () => ({ getConfigApiBaseUrl: () => 'http://host/api/v1' }),
+}))
+
+import { saveExternalPlayerSettings } from '@/api/config'
+
+describe('saveExternalPlayerSettings', () => {
+  beforeEach(() => { vi.restoreAllMocks() })
+
+  it('PUTs values to the player settings endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await saveExternalPlayerSettings('analog-recognition', { songrec_enabled: false })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://host/api/v1/players/analog-recognition/settings',
+      expect.objectContaining({
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ songrec_enabled: false }),
+      }),
+    )
+  })
+
+  it('throws on a non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }))
+    await expect(
+      saveExternalPlayerSettings('analog-recognition', { songrec_enabled: true }),
+    ).rejects.toThrow()
+  })
+})

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -534,6 +534,16 @@ export const scanI2CDevices = async (busNumber?: number): Promise<ConfigApiRespo
 
 // External player registry
 
+export interface PlayerSetting {
+  key: string
+  type: 'toggle' | 'select'
+  label: string
+  description?: string
+  default: boolean | string
+  value: boolean | string
+  options?: { value: string; label: string }[]
+}
+
 export interface ExternalPlayer {
   name: string
   provided_by: string
@@ -542,6 +552,7 @@ export interface ExternalPlayer {
   allow_change: boolean
   maintainer_name: string
   maintainer_url: string
+  settings?: PlayerSetting[]
 }
 
 /**
@@ -566,5 +577,24 @@ export const getExternalPlayers = async (): Promise<ExternalPlayer[]> => {
     return players
   } catch {
     return []
+  }
+}
+
+/**
+ * Persist settings for an external player plugin.
+ */
+export const saveExternalPlayerSettings = async (
+  systemdService: string,
+  values: Record<string, boolean | string>,
+): Promise<void> => {
+  const configStore = useAppConfigStore()
+  const baseUrl = configStore.getConfigApiBaseUrl()
+  const response = await fetch(`${baseUrl}/players/${systemdService}/settings`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(values),
+  })
+  if (!response.ok) {
+    throw new Error(`Failed to save player settings: ${response.status}`)
   }
 }

--- a/src/components/PlayerCard.vue
+++ b/src/components/PlayerCard.vue
@@ -121,6 +121,36 @@
           </div>
         </div>
       </div>
+
+      <!-- Generic external-plugin settings -->
+      <div v-if="player.isExternal && (player.settings?.length ?? 0) > 0" class="config-section">
+        <div v-if="isExpanded" class="config-content">
+          <div class="config-form">
+            <label v-for="setting in player.settings" :key="setting.key" class="config-option">
+              {{ setting.label }}
+              <ToggleSwitch
+                v-if="setting.type === 'toggle'"
+                :model-value="setting.value === true"
+                @update:model-value="(v) => $emit('update-external-setting', setting.key, v)"
+              />
+              <select
+                v-else-if="setting.type === 'select'"
+                :value="setting.value"
+                @change="$emit('update-external-setting', setting.key, ($event.target as HTMLSelectElement).value)"
+                class="version-select"
+              >
+                <option v-for="opt in setting.options" :key="opt.value" :value="opt.value">
+                  {{ opt.label }}
+                </option>
+              </select>
+            </label>
+          </div>
+          <div class="config-actions">
+            <button class="config-btn config-btn--cancel" @click="$emit('cancel-config')" type="button">Cancel</button>
+            <button class="config-btn config-btn--save" @click="$emit('save-config')" type="button">Save</button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -147,6 +177,7 @@ interface Player {
   iconUrl?: string
   maintainerName?: string
   maintainerUrl?: string
+  settings?: { key: string; type: 'toggle' | 'select'; label: string; description?: string; default: boolean | string; value: boolean | string; options?: { value: string; label: string }[] }[]
 }
 
 const props = defineProps<{
@@ -160,11 +191,15 @@ defineEmits<{
   'navigate-bluetooth': []
   'update-airplay-version': [version: number]
   'update-toslink-sensitivity': [sensitivity: string]
+  'update-external-setting': [key: string, value: boolean | string]
   'cancel-config': []
   'save-config': []
 }>()
 
 const hasConfig = computed(() => {
+  if (props.player.isExternal) {
+    return (props.player.settings?.length ?? 0) > 0
+  }
   return (props.player.name === 'Airplay' || props.player.name === 'TOSLink') &&
          typeof props.player.config === 'object'
 })

--- a/src/components/__tests__/PlayerCard.settings.test.ts
+++ b/src/components/__tests__/PlayerCard.settings.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PlayerCard from '@/components/PlayerCard.vue'
+
+const externalPlayer = {
+  name: 'Analog Input',
+  providedBy: 'analog-recognition',
+  systemdService: 'analog-recognition',
+  config: 'none',
+  status: 'inactive',
+  icon: 'analog',
+  enabled: false,
+  exists: true,
+  isExternal: true,
+  settings: [
+    { key: 'songrec_enabled', type: 'toggle', label: 'Recognize tracks',
+      default: true, value: true },
+  ],
+}
+
+describe('PlayerCard generic settings', () => {
+  it('renders a config caret for an external player that has settings', () => {
+    const wrapper = mount(PlayerCard, {
+      props: { player: externalPlayer, isExpanded: false },
+      global: { stubs: { Icon: true, InlineSvg: true, ToggleSwitch: true } },
+    })
+    expect(wrapper.find('.expand-caret').exists()).toBe(true)
+  })
+
+  it('emits update-external-setting when a toggle setting changes', async () => {
+    const wrapper = mount(PlayerCard, {
+      props: { player: externalPlayer, isExpanded: true },
+      global: { stubs: { Icon: true, InlineSvg: true } },
+    })
+    // Scope to the settings row: PlayerCard also renders a top-level
+    // enable/disable ToggleSwitch, so an unscoped findComponent would match
+    // that one instead of the per-setting toggle.
+    const toggle = wrapper.find('.config-option').findComponent({ name: 'ToggleSwitch' })
+    toggle.vm.$emit('update:modelValue', false)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('update-external-setting')?.[0]).toEqual(['songrec_enabled', false])
+  })
+})

--- a/src/views/services/players.vue
+++ b/src/views/services/players.vue
@@ -17,6 +17,7 @@
           @update-toslink-sensitivity="(sensitivity) => updateTOSLinkSensitivity(player.name, sensitivity)"
           @cancel-config="cancelConfig(player.name)"
           @save-config="saveConfig(player.name)"
+          @update-external-setting="(key, value) => updateExternalSetting(player.name, key, value)"
         />
       </div>
       <template v-if="externalVisiblePlayers.length > 0">
@@ -37,6 +38,7 @@
             @update-toslink-sensitivity="(sensitivity) => updateTOSLinkSensitivity(player.name, sensitivity)"
             @cancel-config="cancelConfig(player.name)"
             @save-config="saveConfig(player.name)"
+            @update-external-setting="(key, value) => updateExternalSetting(player.name, key, value)"
           />
         </div>
       </template>
@@ -65,7 +67,8 @@ import {
   enableNowService,
   disableNowService,
   checkSystemdServiceExists,
-  getExternalPlayers
+  getExternalPlayers,
+  saveExternalPlayerSettings
 } from '@/api/config'
 import {
   getTOSLinkStatus,
@@ -90,6 +93,7 @@ interface Player {
   iconUrl?: string
   maintainerName?: string
   maintainerUrl?: string
+  settings?: import('@/api/config').PlayerSetting[]
 }
 
 const players = ref<Player[]>([
@@ -195,7 +199,8 @@ const loadServiceStatus = async () => {
           isExternal: true,
           iconUrl: ext.icon_url,
           maintainerName: ext.maintainer_name || undefined,
-          maintainerUrl: ext.maintainer_url || undefined
+          maintainerUrl: ext.maintainer_url || undefined,
+          settings: ext.settings
         })
         knownServices.add(ext.systemd_service)
       }
@@ -462,6 +467,13 @@ const updateAirplayVersion = (playerName: string, version: number) => {
   }
 }
 
+const updateExternalSetting = (playerName: string, key: string, value: boolean | string) => {
+  const player = players.value[findPlayerIndex(playerName)]
+  if (!player?.settings) return
+  const setting = player.settings.find(s => s.key === key)
+  if (setting) setting.value = value
+}
+
 const updateTOSLinkSensitivity = (playerName: string, sensitivity: string) => {
   const playerIndex = findPlayerIndex(playerName)
   if (playerIndex === -1) return
@@ -505,9 +517,21 @@ const saveConfig = async (playerName: string) => {
   const playerIndex = findPlayerIndex(playerName)
   if (playerIndex === -1) return
 
+  const player = players.value[playerIndex]
+  if (player?.isExternal && player.settings?.length) {
+    const values: Record<string, boolean | string> = {}
+    for (const s of player.settings) values[s.key] = s.value
+    try {
+      await saveExternalPlayerSettings(player.systemdService, values)
+    } catch (e) {
+      player.error = e instanceof Error ? e.message : 'Failed to save settings'
+    }
+    toggleConfigExpanded(playerName)
+    return
+  }
+
   // Save the configuration and close the section
   expandedConfigs.value.delete(playerIndex)
-  const player = players.value[playerIndex]
   console.log(`Configuration saved for ${player.name}`)
 
   try {


### PR DESCRIPTION
## What

Renders and persists **generic plugin settings** for external ("3rd Party") players in the Players view — the frontend half of the plugin-settings capability. First consumer is `analog-recognition`'s "Recognize tracks" toggle.

## Changes

- **`api/config.ts`**: `PlayerSetting` type (`key`/`type` `toggle|select`/`label`/`description?`/`default`/`value`/`options?`); `settings?` added to `ExternalPlayer` (rides through the existing `getExternalPlayers` passthrough); `saveExternalPlayerSettings(service, values)` → `PUT /api/v1/players/<service>/settings`.
- **`views/services/players.vue`**: carries `settings` through the external-player merge; `saveConfig` branches for external players to persist via the API; `updateExternalSetting` handler.
- **`components/PlayerCard.vue`**: `hasConfig` now true for external players with settings; a **generic** config section renders `ToggleSwitch` for `toggle` and `<select>` for `select`, emitting `update-external-setting`. The bespoke Airplay/TOSLink blocks are untouched. The framework is plugin-agnostic — nothing references songrec.

## Testing

Vitest: API save function (PUT payload + error path) and a PlayerCard component test (external-player config caret renders; toggling emits `update-external-setting` with `[key, value]`, scoped to the settings toggle). `vue-tsc --noEmit` clean; full suite green (one pre-existing unrelated `filter-display` failure, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
